### PR TITLE
feat: support notification scoped package

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -65,7 +65,7 @@ function registerResourcePlugins(server, config, callback) {
 }
 
 /**
- * Revise scope name
+ * Revise npm packages's scope name
  * @method reviseScope
  * @param {String} scope 
  */

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -67,7 +67,7 @@ function registerResourcePlugins(server, config, callback) {
 /**
  * Revise npm packages's scope name
  * @method reviseScope
- * @param {String} scope 
+ * @param {String} scope            Name of npm package's scope        
  */
 function reviseScope(scope) {
     if (/^[@].*/.test(scope)) {
@@ -80,8 +80,8 @@ function reviseScope(scope) {
 /**
  * Require notification plugin
  * @method requireNotificationPlugin
- * @param  {Object}    config            Configuration object for nortification plugins.
- * @param  {String}    plugin            nortification plugin name.
+ * @param  {Object}    config            Configuration object for notification plugins.
+ * @param  {String}    plugin            Notification plugin name.
  */
 function requireNotificationPlugin(config, plugin) {
     if (config[plugin].scope) {

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -64,6 +64,33 @@ function registerResourcePlugins(server, config, callback) {
     }, callback);
 }
 
+/**
+ * Revise scope name
+ * @method reviseScope
+ * @param {String} scope 
+ */
+function reviseScope(scope) {
+    if (/^[@].*/.test(scope)) {
+        return scope;
+    }
+
+    return `@${scope}`;
+}
+
+/**
+ * Require notification plugin
+ * @method requireNotificationPlugin
+ * @param  {Object}    config            Configuration object for nortification plugins.
+ * @param  {String}    plugin            nortification plugin name.
+ */
+function requireNotificationPlugin(config, plugin) {
+    if (config[plugin].scope) {
+        return require(`${reviseScope(config[plugin].scope)}/screwdriver-notifications-${plugin}`);
+    }
+
+    return require(`screwdriver-notifications-${plugin}`);
+}
+
 module.exports = (server, config) => (
     new Promise((resolve, reject) => {
         async.series([
@@ -81,7 +108,7 @@ module.exports = (server, config) => (
         const notificationConfig = config.notifications || {};
 
         return Object.keys(notificationConfig).forEach((plugin) => {
-            const Plugin = require(`screwdriver-notifications-${plugin}`);
+            const Plugin = requireNotificationPlugin(notificationConfig, plugin);
             const notificationPlugin = new Plugin(notificationConfig[plugin]);
 
             notificationPlugin.events.forEach((event) => {

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -140,6 +140,41 @@ describe('Register Unit Test Case', () => {
         });
     });
 
+    it('registered scoped notifications plugins', () => {
+        serverMock.register.callsArgAsync(2);
+
+        const newConfig = {
+            notifications: {
+                email: {
+                    foo: 'abc',
+                    scope: 'module'
+                },
+                slack: {
+                    baz: 'def',
+                    scope: '@module'
+                }
+            }
+        };
+
+        const notificationPlugins = [
+            '@module/screwdriver-notifications-email',
+            '@module/screwdriver-notifications-slack'
+        ];
+
+        notificationPlugins.forEach((plugin) => {
+            mocks[plugin] = sinon.stub();
+            mocks[plugin].prototype.events = ['build_status'];
+            mocks[plugin].prototype.notify = sinon.stub();
+            mockery.registerMock(plugin, mocks[plugin]);
+        });
+
+        return main(serverMock, newConfig).then(() => {
+            notificationPlugins.forEach(() =>
+                Assert.calledTwice(serverMock.on)
+            );
+        });
+    });
+
     it('bubbles failures up', () => {
         serverMock.register.callsArgWithAsync(2, new Error('failure loading'));
 


### PR DESCRIPTION
## Context
Now we can't use scoped notification package.
Due to this change user can use scoped notification package by setting "scope" in config file.

## Objective
Change how to require notification packages. 

## References

