### PR TITLE
fix: delete scope from constructor config

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -65,6 +65,17 @@ function registerResourcePlugins(server, config, callback) {
 }
 
 /**
+ * Revise each notification plugins config
+ * @param  {Object} config          Config of each notification plugin
+ * @return {Object}                 Revised config
+ */
+function reviseNotificationConfig(config) {
+    delete config.scope;
+
+    return config;
+}
+
+/**
  * Revise npm packages's scope name
  * @method reviseScope
  * @param  {String} scope           Name of npm package's scope
@@ -111,7 +122,8 @@ module.exports = (server, config) => (
 
         return Object.keys(notificationConfig).forEach((plugin) => {
             const Plugin = requireNotificationPlugin(notificationConfig, plugin);
-            const notificationPlugin = new Plugin(notificationConfig[plugin]);
+            const revisedConfig = reviseNotificationConfig(notificationConfig[plugin]);
+            const notificationPlugin = new Plugin(revisedConfig);
 
             notificationPlugin.events.forEach((event) => {
                 server.on(event, buildData => notificationPlugin.notify(buildData));


### PR DESCRIPTION
## Context
This [PR](https://github.com/screwdriver-cd/screwdriver/pull/772) made it possible to use scoped notification package. Notification packages will attempt the config is validate or not in constructor, thus now when we use scoped notification package,  we have to add scope key in source of notification package. We should not set scope in each notification packages, because scope is not config of notification.  So I send this PR.

## Objective
delete scope setting before initialize notification packages.

## References
[validate code in email nortification](https://github.com/screwdriver-cd/notifications-email/blob/master/index.js#L58-L59)