### PR TITLE
add sd-cmd feature.

### DIFF
--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -24,7 +24,7 @@ Feature: SD Command
             | local  | ./foobar.hart   | git    | -baz sample |
 
     Scenario: Execute a command of docker format
-        Given command specification as image: "node:1.2.3"
+        Given command specification as image: "node:6"
         When execute the command with arguments: "-baz sample"
         Then the command finishes successfully
 
@@ -33,12 +33,12 @@ Feature: SD Command
         When execute the command with arguments: "-baz sample"
         Then the command finishes successfully
 
-    Scenario: Pulish command
+    Scenario: Pulish a command
         Given command specification file
         When execute publish
         Then the command to be successfully published
 
-    Scenario: Promote command
+    Scenario: Promote a command
         Given promoting version is "1.0.1"
         And promoting target is "latest"
         And currently "1.0.0" is tagged to "latest"

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -33,7 +33,7 @@ Feature: SD Command
         When execute the command with arguments: "git --version"
         Then the command finishes successfully
 
-    Scenario: Pulish a command
+    Scenario: Publish a command
         Given command specification file
         When execute publish
         Then the command to be successfully published

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -8,9 +8,9 @@ Feature: Commands
     (via remote binary, docker image, or habitat package) during a build.
 
     Background:
-        Given an existing pipeline with a command:
-            | namespace   | command        | version |
-            | sd-cmd-test | sample-command | 1.0.0   |
+        Given an existing pipeline with <image> image and a command:
+            | image         | namespace   | command        | version |
+            | golang:latest | sd-cmd-test | sample-command | 1.0.0   |
 
     Scenario Outline: Execute a command of habitat format
         Given command specifications as mode: <mode>, package: <package>, binary: <binary>
@@ -19,18 +19,18 @@ Feature: Commands
         Then the command finishes successfully
 
         Examples:
-            | mode   | package         | binary | arguments     |
-            | remote | core/git/2.14.1 | git    | git --version |
-            | local  | ./sample.hart   | git    | git --version |
+            | mode   | package         | binary | arguments |
+            | remote | core/node/8.9.1 | node   | node -v   |
+            | local  | ./sample.hart   | node   | node -v   |
 
     Scenario: Execute a command of docker format
         Given command specification as image: "node:6"
-        When execute the command with arguments: "node --version"
+        When execute the command with arguments: "node -v"
         Then the command finishes successfully
 
     Scenario: Execute a command of binary format
         Given command specification as file: "./sample.sh"
-        When execute the command with arguments: "git --version"
+        When execute the command with arguments: "node -v"
         Then the command finishes successfully
 
     Scenario: Publish a command

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -1,0 +1,59 @@
+@ignore
+Feature: SD Command
+
+    Users want to share binaries or scripts across multiple containers
+    so that they can easily use some commands in all containers.
+
+    Screwdriver should have a single interface for executing a versioned command
+    (via remote binary, docker image, or habitat package) during a build.
+
+    Background:
+        Given an existing pipeline with a command:
+            | namespace | command | version |
+            | foo       | bar     | 1.0.0   |
+
+    Scenario Outline: Execute command in habitat
+        Given command specifications as mode: <mode>, package: <package>, binary: <binary>
+        When the command package mode is <mode>
+        And execute with arguments: <arguments>
+        Then the command finishes successfully
+
+        Examples:
+            | mode   | package         | binary | arguments   |
+            | remote | core/git/2.14.1 | git    | -baz sample |
+            | local  | ./foobar.hart   | git    | -baz sample |
+
+    Scenario: Execute command in docker
+        Given a command specification:
+            | image      | arguments   |
+            | node:1.2.3 | -baz sample |
+        When execute the command with arguments: <arguments>
+        Then the command finishes successfully
+
+    Scenario: Execute command in binary
+        Given a command specification:
+            | file        | arguments   |
+            | ./foobar.sh | -baz sample |
+        When execute the command with arguments: <arguments>
+        Then the command finishes successfully
+
+    Scenario: Command publish
+        Given a command specification file
+        When execute publish
+        Then the command to be successfully published
+
+    Scenario Outline: Command promote
+        Given promoting version is <promoting_version>
+        And removing version is <removing_version>
+        And promoting target is <tag>
+        When execute promote
+        Then promote <promoting_version> to <tag>
+        And remove <removing_version> from <tag>
+
+        Examples:
+            | tag    | promoting_version | removing_version |
+            | latest | 1.0.1             | 1.0.0            |
+
+    Scenario: Get list of explicit command versions
+        When execute list
+        Then get list of explicit versions matching that range with comma separated tags next to applicable tags

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -1,5 +1,5 @@
 @ignore
-Feature: SD Command
+Feature: Commands
 
     Users want to share binaries or scripts across multiple containers
     so that they can easily use some commands in all containers.
@@ -35,17 +35,17 @@ Feature: SD Command
 
     Scenario: Publish a command
         Given command specification file
-        When execute publish
+        When execute "publish"
         Then the command to be successfully published
 
     Scenario: Promote a command
         Given promoting version is "1.0.1"
         And promoting target is "latest"
         And currently "1.0.0" is tagged to "latest"
-        When execute promote
+        When execute "promote"
         Then promote "1.0.1" to "latest"
         And remove "1.0.0" from "latest"
 
     Scenario: Get list of explicit command versions
-        When execute list
+        When execute "list"
         Then get list of explicit versions matching that range with comma separated tags next to applicable tags

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -9,28 +9,28 @@ Feature: SD Command
 
     Background:
         Given an existing pipeline with a command:
-            | namespace | command | version |
-            | foo       | bar     | 1.0.0   |
+            | namespace   | command        | version |
+            | sd-cmd-test | sample-command | 1.0.0   |
 
     Scenario Outline: Execute a command of habitat format
         Given command specifications as mode: <mode>, package: <package>, binary: <binary>
         When the command package mode is <mode>
-        And execute with arguments: <arguments>
+        And execute the command with arguments: <arguments>
         Then the command finishes successfully
 
         Examples:
-            | mode   | package         | binary | arguments   |
-            | remote | core/git/2.14.1 | git    | -baz sample |
-            | local  | ./foobar.hart   | git    | -baz sample |
+            | mode   | package         | binary | arguments     |
+            | remote | core/git/2.14.1 | git    | git --version |
+            | local  | ./sample.hart   | git    | git --version |
 
     Scenario: Execute a command of docker format
         Given command specification as image: "node:6"
-        When execute the command with arguments: "-baz sample"
+        When execute the command with arguments: "node --version"
         Then the command finishes successfully
 
     Scenario: Execute a command of binary format
-        Given command specification as file: "./foobar.sh"
-        When execute the command with arguments: "-baz sample"
+        Given command specification as file: "./sample.sh"
+        When execute the command with arguments: "git --version"
         Then the command finishes successfully
 
     Scenario: Pulish a command

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -12,7 +12,7 @@ Feature: SD Command
             | namespace | command | version |
             | foo       | bar     | 1.0.0   |
 
-    Scenario Outline: Execute command in habitat
+    Scenario Outline: Execute a command of habitat format
         Given command specifications as mode: <mode>, package: <package>, binary: <binary>
         When the command package mode is <mode>
         And execute with arguments: <arguments>
@@ -23,36 +23,28 @@ Feature: SD Command
             | remote | core/git/2.14.1 | git    | -baz sample |
             | local  | ./foobar.hart   | git    | -baz sample |
 
-    Scenario: Execute command in docker
-        Given a command specification:
-            | image      | arguments   |
-            | node:1.2.3 | -baz sample |
-        When execute the command with arguments: <arguments>
+    Scenario: Execute a command of docker format
+        Given command specification as image: "node:1.2.3"
+        When execute the command with arguments: "-baz sample"
         Then the command finishes successfully
 
-    Scenario: Execute command in binary
-        Given a command specification:
-            | file        | arguments   |
-            | ./foobar.sh | -baz sample |
-        When execute the command with arguments: <arguments>
+    Scenario: Execute a command of binary format
+        Given command specification as file: "./foobar.sh"
+        When execute the command with arguments: "-baz sample"
         Then the command finishes successfully
 
-    Scenario: Command publish
-        Given a command specification file
+    Scenario: Pulish command
+        Given command specification file
         When execute publish
         Then the command to be successfully published
 
-    Scenario Outline: Command promote
-        Given promoting version is <promoting_version>
-        And removing version is <removing_version>
-        And promoting target is <tag>
+    Scenario: Promote command
+        Given promoting version is "1.0.1"
+        And promoting target is "latest"
+        And currently "1.0.0" is tagged to "latest"
         When execute promote
-        Then promote <promoting_version> to <tag>
-        And remove <removing_version> from <tag>
-
-        Examples:
-            | tag    | promoting_version | removing_version |
-            | latest | 1.0.1             | 1.0.0            |
+        Then promote "1.0.1" to "latest"
+        And remove "1.0.0" from "latest"
 
     Scenario: Get list of explicit command versions
         When execute list


### PR DESCRIPTION
## Context
Currently we can't share binaries or scripts across multiple containers to use some commands in all containers. We need a single interface for executing a versioned command during a build.

## Objective
This PR adds feature file for sd-cmd functional testing.

## References
https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md