### PR TITLE
add: common triggers tests

### DIFF
--- a/test/plugins/data/trigger/~a_b.yaml
+++ b/test/plugins/data/trigger/~a_b.yaml
@@ -1,0 +1,15 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  a:
+    requires: [ ~hub ]
+  b:
+    requires: [ ~hub ]
+  target:
+    requires: [ ~a, b ]
+

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -196,20 +196,6 @@ describe('trigger tests', () => {
         assert.isNull(restartEvent.getBuildOf('target'));
     });
 
-    it('[ ~a ] is not triggered when a fails', async () => {
-        const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
-
-        const event = eventFactoryMock.create({
-            pipelineId: pipeline.id,
-            startFrom: 'hub'
-        });
-
-        await event.getBuildOf('hub').complete('SUCCESS');
-        await event.getBuildOf('a').complete('FAILURE');
-
-        assert.isNull(event.getBuildOf('target'));
-    });
-
     it('[ ~a ] is triggered when a fails once and then restarts and succeeds', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
 

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -93,6 +93,24 @@ describe('trigger tests', () => {
         server = null;
     });
 
+    it('[ ~a ] is triggered when a　succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+    });
+
     it('[ ~a ] is triggered and is triggered again when a restarts', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
 
@@ -142,6 +160,18 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target2').status, 'SUCCESS');
     });
 
+    it('[ ~a ] is not triggered when a fails', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+    });
     it('[ ~a ] is not triggered when a restarts and fails', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
 
@@ -204,6 +234,24 @@ describe('trigger tests', () => {
         assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
     });
 
+    it('[ a ] is triggered', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+    });
+
     it('[ a ] is triggered and is triggered again when a restarts', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a.yaml');
 
@@ -230,6 +278,19 @@ describe('trigger tests', () => {
         await restartEvent.getBuildOf('target').complete('SUCCESS');
 
         assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+    });
+
+    it('[ a ] is not triggered when a fails', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
     });
 
     it('[ a ] is not triggered when a restarts and fails', async () => {
@@ -301,6 +362,25 @@ describe('trigger tests', () => {
         assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
     });
 
+    it('[ ~a, ~b ] is triggered', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_~b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
     it('[ ~a, ~b ] is triggered by a once', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a_~b.yaml');
 
@@ -320,8 +400,8 @@ describe('trigger tests', () => {
         assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
     });
 
-    it('[ ~a, b, c ] is triggered by a once', async () => {
-        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+    it('[ ~a, ~b ] is triggered and is triggered again when a restarts', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_~b.yaml');
 
         const event = eventFactoryMock.create({
             pipelineId: pipeline.id,
@@ -336,7 +416,132 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
         await event.getBuildOf('b').complete('SUCCESS');
-        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+
+        const restartEvent = event.restartFrom('a');
+
+        await restartEvent.getBuildOf('a').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+
+        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+    });
+
+    it('[ ~a, ~b ] is triggered when a fails', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_~b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b ] is triggered', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b ] is triggered when a fails once and then restarts and succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+
+        const restartEvent = event.restartFrom('a');
+
+        await restartEvent.getBuildOf('a').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+    });
+
+    it('[ ~a, b ] is triggered when b fails once and then restarts and succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('b').complete('FAILURE');
+
+        const restartEvent = event.restartFrom('b');
+
+        await restartEvent.getBuildOf('b').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+    });
+
+    it('[ ~a, b ] is triggered when a fails and b succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b ] is triggered when b fails and a succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('b').complete('FAILURE');
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
         assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
     });
 
@@ -359,6 +564,76 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
     });
 
+    it('[ a, b ] is triggered when a restarts', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        const restartEvent = event.restartFrom('a');
+
+        await restartEvent.getBuildOf('a').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+    });
+
+    it('[ a, b ] is not triggered if only a succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        assert.notEqual(event.getBuildOf('target').status, 'SUCCESS');
+    });
+
+    it('[ a, b ] is triggered when b fails once and then restarts and succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+
+        const build = event.getBuildOf('target');
+
+        await event.getBuildOf('b').complete('FAILURE');
+        assert.equal(build.status, 'CREATED');
+        assert.isNull(event.getBuildOf('target'));
+
+        const restartEvent = event.restartFrom('b');
+
+        await restartEvent.getBuildOf('b').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+    });
+
     it('[ a, b ] is not triggered when b was failed', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
 
@@ -375,6 +650,216 @@ describe('trigger tests', () => {
         await event.getBuildOf('b').complete('FAILURE');
         assert.equal(build.status, 'CREATED');
         assert.isNull(event.getBuildOf('target'));
+    });
+
+    it('[ a, b ] is not triggered when a was failed and b succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.isNull(event.getBuildOf('target'));
+    });
+
+    it('[ a, b ] is not triggered when a was failed and b restarted and succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.isNull(event.getBuildOf('target'));
+
+        const restartEvent = event.restartFrom('b');
+
+        await restartEvent.getBuildOf('b').complete('SUCCESS');
+        assert.isNull(restartEvent.getBuildOf('target'));
+    });
+
+    it('[ ~a, b, c ] is triggered by a once', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b, c ] is triggered when a succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+    });
+
+    it('[ ~a, b, c ] is triggered when b and a, c succeed', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+    it('[ ~a, b, c ] is triggered when a fails and b and c succeed', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b, c ] is triggered when b and a, c succeed', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('a').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+
+        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b, c ] is triggered when a fails and b and c succeed', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('c').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b, c ] is not triggered when a and c fail but b succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('c').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+    });
+
+    it('[ ~a, b, c ] is triggered when a and c fails, b succeeds, and then c restarts and succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'CREATED');
+
+        await event.getBuildOf('c').complete('FAILURE');
+        assert.isNull(event.getBuildOf('target'));
+
+        const restartEvent = event.restartFrom('c');
+
+        await restartEvent.getBuildOf('c').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+
+        await restartEvent.getBuildOf('target').complete('SUCCESS');
+        assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
     });
 
     xit('[ a, c ] is not triggered when restart a b and only a was completed', async () => {

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -93,7 +93,7 @@ describe('trigger tests', () => {
         server = null;
     });
 
-    it('[ ~a ] is triggered when a　succeeds', async () => {
+    it('[ ~a ] is triggered when a succeeds', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a.yaml');
 
         const event = eventFactoryMock.create({

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -121,12 +121,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('hub').complete('SUCCESS');
         await event.getBuildOf('a').complete('SUCCESS');
-
-        assert.equal(event.getBuildOf('target').status, 'RUNNING');
-
         await event.getBuildOf('target').complete('SUCCESS');
-
-        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
         const restartEvent = event.restartFrom('a');
 
@@ -364,7 +359,7 @@ describe('trigger tests', () => {
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ ~a, ~b ] is triggered by a once', async () => {
@@ -381,9 +376,6 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
-
-        await event.getBuildOf('b').complete('SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
     });
 
     it('[ ~a, ~b ] is triggered and is triggered again when a restarts', async () => {
@@ -400,9 +392,6 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
-
-        await event.getBuildOf('b').complete('SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
 
         const restartEvent = event.restartFrom('a');
 
@@ -443,14 +432,30 @@ describe('trigger tests', () => {
         });
 
         await event.getBuildOf('hub').complete('SUCCESS');
-        await event.getBuildOf('a').complete('FAILURE');
+        await event.getBuildOf('a').complete('SUCCESS');
         await event.getBuildOf('b').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'RUNNING');
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
+    });
+
+    it('[ ~a, b ] is triggered when b succeeds', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('~a_b.yaml');
+
+        const event = eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('b').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'RUNNING');
+
+        await event.getBuildOf('target').complete('SUCCESS');
+        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
     });
 
     it('[ ~a, b ] is triggered when a fails once and then restarts and succeeds', async () => {
@@ -492,7 +497,6 @@ describe('trigger tests', () => {
 
         await restartEvent.getBuildOf('target').complete('SUCCESS');
         assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
     });
 
     it('[ ~a, b ] is triggered when a fails and b succeeds', async () => {
@@ -510,7 +514,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ ~a, b ] is triggered when b fails and a succeeds', async () => {
@@ -528,7 +532,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ a, b ] is triggered', async () => {
@@ -548,6 +552,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ a, b ] is triggered when a restarts', async () => {
@@ -560,13 +565,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('hub').complete('SUCCESS');
         await event.getBuildOf('a').complete('SUCCESS');
-        assert.equal(event.getBuildOf('target').status, 'CREATED');
-
         await event.getBuildOf('b').complete('SUCCESS');
-        assert.equal(event.getBuildOf('target').status, 'RUNNING');
-
-        await event.getBuildOf('target').complete('SUCCESS');
-        assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
         const restartEvent = event.restartFrom('a');
 
@@ -575,7 +574,8 @@ describe('trigger tests', () => {
 
         await restartEvent.getBuildOf('target').complete('SUCCESS');
         assert.equal(restartEvent.getBuildOf('target').status, 'SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(restartEvent.id), null);
+
+        assert.equal(pipeline.getBuildsOf('target').length, 2);
     });
 
     it('[ a, b ] is not triggered if only a succeeds', async () => {
@@ -589,8 +589,6 @@ describe('trigger tests', () => {
         await event.getBuildOf('hub').complete('SUCCESS');
         await event.getBuildOf('a').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'CREATED');
-
-        assert.notEqual(event.getBuildOf('target').status, 'SUCCESS');
     });
 
     it('[ a, b ] is triggered when b fails once and then restarts and succeeds', async () => {
@@ -692,7 +690,8 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('b').complete('SUCCESS');
         await event.getBuildOf('c').complete('SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ ~a, b, c ] is triggered when a succeeds', async () => {
@@ -730,7 +729,7 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
         await event.getBuildOf('c').complete('SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
     it('[ ~a, b, c ] is triggered when a fails and b and c succeed', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a_b_c.yaml');
@@ -752,7 +751,7 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('target').complete('SUCCESS');
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ ~a, b, c ] is triggered when b and a, c succeed', async () => {
@@ -774,7 +773,7 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'SUCCESS');
 
         await event.getBuildOf('c').complete('SUCCESS');
-        assert.equal(eventFactoryMock.getRunningBuild(event.id), null);
+        assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
     it('[ ~a, b, c ] is triggered when a fails and b and c succeed', async () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This PR is one of the PR that add a test for triggers.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I added the following test

```
    ✔ [ ~a ] is triggered when a succeeds
    ✔ [ ~a ] is not triggered when a fails
    ✔ [ ~a ] is triggered when a fails once and then restarts and succeeds
    ✔ [ a ] is triggered
    ✔ [ ~a, ~b ] is triggered
    ✔ [ ~a, ~b ] is triggered and is triggered again when a restarts
    ✔ [ ~a, ~b ] is triggered when a fails
    ✔ [ ~a, b ] is triggered
    ✔ [ ~a, b ] is triggered when a fails once and then restarts and succeeds
    ✔ [ ~a, b ] is triggered when b fails once and then restarts and succeeds
    ✔ [ ~a, b ] is triggered when a fails and b succeeds
    ✔ [ ~a, b ] is triggered when b fails and a succeeds
    ✔ [ a, b ] is triggered
    ✔ [ a, b ] is triggered when a restarts
    ✔ [ a, b ] is not triggered if only a succeeds
    ✔ [ a, b ] is triggered when b fails once and then restarts and succeeds
    ✔ [ a, b ] is not triggered when b was failed
    ✔ [ a, b ] is not triggered when a was failed and b succeeds
    ✔ [ a, b ] is not triggered when a was failed and b restarted and succeeds
    ✔ [ ~a, b, c ] is triggered by a once
    ✔ [ ~a, b, c ] is triggered when a succeeds
    ✔ [ ~a, b, c ] is triggered when b and a, c succeed
    ✔ [ ~a, b, c ] is triggered when a fails and b and c succeed
    ✔ [ ~a, b, c ] is triggered when b and a, c succeed
    ✔ [ ~a, b, c ] is triggered when a fails and b and c succeed
    ✔ [ ~a, b, c ] is not triggered when a and c fail but b succeeds
    ✔ [ ~a, b, c ] is triggered when a and c fails, b succeeds, and then c restarts and succeeds
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
