### PR TITLE
fix: refactoring `AND trigger`

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -27,6 +27,7 @@ const {
     parseJobInfo,
     handleStageFailure,
     getJobId,
+    isOrTrigger,
     extractExternalPipelineJoinData,
     extractCurrentPipelineJoinData
 } = require('./triggers/helpers');
@@ -110,10 +111,10 @@ async function triggerNextJobs(config, app) {
                      * 2. ([~D,B,C]->A) currentJob=D, nextJob=A, joinList(A)=[B,C]
                      *    joinList doesn't include D, so start A
                      */
-                    if (joinListNames.includes(current.job.name)) {
-                        await andTrigger.run(nextJobName, nextJobId, parentBuilds, joinListNames);
-                    } else {
+                    if (isOrTrigger(currentEvent.workflowGraph, currentJob.name, nextJobName)) {
                         await orTrigger.run(nextJobName, nextJobId, parentBuilds);
+                    } else {
+                        await andTrigger.run(nextJobName, nextJobId, parentBuilds, joinListNames);
                     }
                 } catch (err) {
                     logger.error(

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -66,7 +66,7 @@ class AndTrigger {
      * @return {Promise<BuildModel[]|null>}
      */
     async fetchFinishedBuilds(event, buildFactory, eventFactory, pipelineId) {
-        let finishedBuilds = await getFinishedBuilds(event, buildFactory);
+        const finishedBuilds = await getFinishedBuilds(event, buildFactory);
 
         if (event.parentEventId) {
             // FIXME: On restart cases parentEventId should be fetched
@@ -77,7 +77,7 @@ class AndTrigger {
                 pipelineId
             });
 
-            finishedBuilds = finishedBuilds.concat(parallelBuilds);
+            finishedBuilds.push(...parallelBuilds);
         }
 
         return finishedBuilds;

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -140,10 +140,9 @@ class AndTrigger {
 
             newBuild = await createInternalBuild(internalBuildConfig);
         } else {
-            // nextBuild is not build model, so fetch proper build
             newBuild = await updateParentBuilds({
                 joinParentBuilds: parentBuilds,
-                nextBuild: await this.buildFactory.get(nextBuild.id),
+                nextBuild,
                 build: this.currentBuild
             });
         }

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -11,12 +11,37 @@ const {
     getFinishedBuilds
 } = require('./helpers');
 
-// =============================================================================
-//
-//      Function
-//
-// =============================================================================
+/**
+ * @typedef {import('screwdriver-models').EventFactory} EventFactory
+ * @typedef {import('screwdriver-models').BuildFactory} BuildFactory
+ * @typedef {import('screwdriver-models').JobFactory} JobFactory
+ * @typedef {import('screwdriver-models').PipelineFactory} PipelineFactory
+ * @typedef {import('screwdriver-models/lib/pipeline').PipelineModel} PipelineModel
+ * @typedef {import('screwdriver-models/lib/event').EventModel} EventModel
+ * @typedef {import('screwdriver-models/lib/job').Job} JobModel
+ * @typedef {import('screwdriver-models/lib/build').BuildModel} BuildModel
+ * @typedef {import('screwdriver-models/lib/stage').StageModel} StageModel
+ */
+/**
+ * @property {EventFactory} eventFactory
+ * @property {BuildFactory} buildFactory
+ * @property {JobFactory} jobFactory
+ * @property {PipelineFactory} pipelineFactory
+ * @property {PipelineModel} currentPipeline
+ * @property {EventModel} currentEvent
+ * @property {JobModel} currentJob
+ * @property {BuildModel} currentBuild
+ * @property {number} username
+ * @property {string} scmContext
+ * @property {StageModel} stage
+ */
 class AndTrigger {
+    /**
+     * Trigger the next jobs of the current job
+     * @param {import('../types/index').ServerApp} app                      Server app object
+     * @param {import('../types/index').ServerConfig} config              Configuration object
+     * @param {import('screwdriver-models/lib/event').EventModel} currentEvent
+     */
     constructor(app, config, currentEvent) {
         this.eventFactory = app.eventFactory;
         this.buildFactory = app.buildFactory;
@@ -32,26 +57,52 @@ class AndTrigger {
         this.stage = config.stage;
     }
 
-    async run(nextJobName, nextJobId, parentBuilds, joinListNames) {
-        logger.info(`Fetching finished builds for event ${this.currentEvent.id}`);
-        let finishedInternalBuilds = await getFinishedBuilds(this.currentEvent, this.buildFactory);
+    /**
+     * Get finished builds related to current event
+     * @param {EventModel} event
+     * @param {BuildFactory} buildFactory
+     * @param {EventFactory} eventFactory
+     * @param {string} pipelineId
+     * @return {Promise<BuildModel[]|null>}
+     */
+    async fetchFinishedBuilds(event, buildFactory, eventFactory, pipelineId) {
+        const finishedBuilds = await getFinishedBuilds(event, buildFactory);
 
-        if (this.currentEvent.parentEventId) {
+        if (event.parentEventId) {
             // FIXME: On restart cases parentEventId should be fetched
             // from first event in the group
             const parallelBuilds = await getParallelBuilds({
-                eventFactory: this.eventFactory,
-                parentEventId: this.currentEvent.parentEventId,
-                pipelineId: this.currentPipeline.id
+                eventFactory,
+                parentEventId: event.parentEventId,
+                pipelineId
             });
 
-            finishedInternalBuilds = finishedInternalBuilds.concat(parallelBuilds);
+            finishedBuilds.push(parallelBuilds);
         }
 
-        let nextBuild;
+        return finishedBuilds;
+    }
 
-        // If next build is internal, look at the finished builds for this event
-        nextBuild = finishedInternalBuilds.find(b => b.jobId === nextJobId && b.eventId === this.currentEvent.id);
+    /**
+     * Trigger the next jobs of the current job
+     * @param {string} nextJobName
+     * @param {string} nextJobId
+     * @param {Record<string, ParentBuild>} parentBuilds
+     * @param {string[]} joinListNames List of names to join
+     * @return {Promise<BuildModel|null>}
+     */
+    async run(nextJobName, nextJobId, parentBuilds, joinListNames) {
+        logger.info(`Fetching finished builds for event ${this.currentEvent.id}`);
+
+        const finishedBuilds = await this.fetchFinishedBuilds(
+            this.currentEvent,
+            this.buildFactory,
+            this.eventFactory,
+            this.currentPipeline.id
+        );
+
+        // Find the next build from the finished builds for this event
+        let nextBuild = finishedBuilds.find(b => b.jobId === nextJobId && b.eventId === this.currentEvent.id);
 
         if (!nextBuild) {
             // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
@@ -63,11 +114,11 @@ class AndTrigger {
             });
 
             if (nextBuild) {
-                finishedInternalBuilds = finishedInternalBuilds.concat(nextBuild);
+                finishedBuilds.push(nextBuild);
             }
         }
 
-        fillParentBuilds(parentBuilds, this.currentPipeline, this.currentEvent, finishedInternalBuilds);
+        fillParentBuilds(parentBuilds, this.currentPipeline, this.currentEvent, finishedBuilds);
 
         let newBuild;
 
@@ -121,11 +172,6 @@ class AndTrigger {
     }
 }
 
-// =============================================================================
-//
-//      module.exports
-//
-// =============================================================================
 module.exports = {
     AndTrigger
 };

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -66,7 +66,7 @@ class AndTrigger {
      * @return {Promise<BuildModel[]|null>}
      */
     async fetchFinishedBuilds(event, buildFactory, eventFactory, pipelineId) {
-        const finishedBuilds = await getFinishedBuilds(event, buildFactory);
+        let finishedBuilds = await getFinishedBuilds(event, buildFactory);
 
         if (event.parentEventId) {
             // FIXME: On restart cases parentEventId should be fetched
@@ -77,7 +77,7 @@ class AndTrigger {
                 pipelineId
             });
 
-            finishedBuilds.push(parallelBuilds);
+            finishedBuilds = finishedBuilds.concat(parallelBuilds);
         }
 
         return finishedBuilds;

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -450,14 +450,22 @@ function parseJobInfo({ joinObj, currentBuild, currentPipeline, currentJob, next
  * @return {Promise}                            All finished builds
  */
 async function getFinishedBuilds(event, buildFactory) {
-    // FIXME: buildFactory.getLatestBuilds doesn't return build model
     const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId, readOnly: false });
 
     builds.forEach(b => {
         try {
+            b.environment = JSON.parse(b.environment);
             b.parentBuilds = JSON.parse(b.parentBuilds);
+            b.stats = JSON.parse(b.stats);
+            b.meta = JSON.parse(b.meta);
+            if (b.parentBuildId) {
+                // parentBuildId could be the string '123', the number 123, or an array
+                b.parentBuildId = Array.isArray(b.parentBuildId)
+                    ? b.parentBuildId.map(Number)
+                    : [Number(b.parentBuildId)];
+            }
         } catch (err) {
-            logger.error(`Failed to parse parentBuilds for ${b.id}`);
+            logger.error(`Failed to parse objects for ${b.id}`);
         }
     });
 

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -482,7 +482,6 @@ async function updateParentBuilds({ joinParentBuilds, nextBuild, build }) {
     // nextBuild.parentBuildId may be int or Array, so it needs to be flattened
     nextBuild.parentBuildId = Array.from(new Set([build.id, nextBuild.parentBuildId || []].flat()));
 
-    // FIXME: Is this needed ? Why not update once in handleNewBuild()
     return nextBuild.update();
 }
 
@@ -634,7 +633,6 @@ function fillParentBuilds(parentBuilds, currentPipeline, currentEvent, builds, n
                 } else if (nextEvent) {
                     if (+pid !== nextEvent.pipelineId) {
                         // parentBuild is remote triggered from external event
-                        // FIXME:: Will else condition ever be true ?
                         searchJob = `sd@${pid}:${searchJob}`;
                     }
                     workflowGraph = nextEvent.workflowGraph;
@@ -918,6 +916,19 @@ async function getJobId(jobName, pipelineId, jobFactory) {
     return job.id;
 }
 
+/**
+ *
+ * @param workflowGraph
+ * @param currentJobName
+ * @param nextJobName
+ * @return {boolean}
+ */
+function isOrTrigger(workflowGraph, currentJobName, nextJobName) {
+    return workflowGraph.edges.some(edge => {
+        return edge.src === currentJobName && edge.dest === nextJobName && edge.join !== true;
+    });
+}
+
 module.exports = {
     Status,
     parseJobInfo,
@@ -936,6 +947,7 @@ module.exports = {
     createEvent,
     deleteBuild,
     getJobId,
+    isOrTrigger,
     extractCurrentPipelineJoinData,
     extractExternalPipelineJoinData
 };

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -121,10 +121,9 @@ class RemoteJoin {
 
             if (nextBuild) {
                 // update current build info in parentBuilds
-                // nextBuild is not build model, so fetch proper build
                 newBuild = await updateParentBuilds({
                     joinParentBuilds: parentBuilds,
-                    nextBuild: await this.buildFactory.get(nextBuild.id),
+                    nextBuild,
                     build: this.currentBuild
                 });
             } else {

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -903,7 +903,7 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'RUNNING');
     });
 
-    xit('[ ~a, a, b ] is triggered when a succeeds', async () => {
+    it('[ ~a, a, b ] is triggered when a succeeds', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~a_a_b.yaml');
 
         const event = await eventFactoryMock.create({


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Proceed with refactoring of `AND trigger` processing

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Change the logic for determining OR or AND triggers.
  - `requires: [ ~a, a, b ]`, etc. so that it can be triggered correctly from jobs that are included in both OR and AND.
- Parse json object to avoid fetching "nextBuild" in vain.
- Other cutouts to functions, etc.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3012

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
